### PR TITLE
tidy up go ci

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -29,7 +29,8 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,11 +18,6 @@ jobs:
   gotest:
     name: Format Check, Analysis and Test
 
-    strategy:
-      matrix:
-        go-version: ['1.20']
-        os: [ubuntu-latest]
-      fail-fast: false
     runs-on: ubuntu-latest
 
     steps:
@@ -32,15 +27,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go-version }}
-
-      - name: Use cache
-        uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
 
       - name: Run go mod tidy
         run: |


### PR DESCRIPTION
不要そうな記述をCIから消しときました

Go modのキャッシュは cache action を使わなくても setup-go 側で吸収すればよさそう。