### PR TITLE
fix: votingTerm for CNDF2023

### DIFF
--- a/internal/cfp/domain/domain.go
+++ b/internal/cfp/domain/domain.go
@@ -37,7 +37,7 @@ func init() {
 	}
 	votingTerms[value.CNDF2023] = VotingTerm{
 		Start: time.Date(2023, 5, 2, 0, 0, 0, 0, jst),
-		End:   time.Date(2023, 6, 25, 18, 0, 0, 0, jst), // TODO adjust
+		End:   time.Date(2023, 6, 19, 23, 59, 0, 0, jst),
 	}
 	votingTerms[value.CNDT2023] = VotingTerm{
 		Start: time.Date(2023, 9, 1, 0, 0, 0, 0, jst),    // TODO adjust


### PR DESCRIPTION
CNDF2023のCFP投票期間を修正しました。
設定値は6/18のDK定例で決めた値になります。
see: https://www.notion.so/cloudnativedays/2023-06-18-2ed13f52cd0f43e892da11cb236a92c5

