### PR TITLE
fix: Not to use docker host-network

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test: fmt vet
 
 .PHONY: build
 build:
-	go build -o dkw cmd/main.go
+	go build -o dkw cmd/dkw/main.go
 
 .PHONY: generate
 generate:

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -1,11 +1,7 @@
 export UID := $(shell id -u)
 
-up: ${HOME}/.local/share/serviceweaver
+up:
 	docker compose up -d
-
-${HOME}/.local/share/serviceweaver:
-	mkdir -p ${HOME}/.local/share/serviceweaver
-	chown -R ${USER} ${HOME}/.local/share/serviceweaver
 
 down:
 	docker compose down

--- a/dev/compose.yaml
+++ b/dev/compose.yaml
@@ -5,16 +5,12 @@ services:
       dockerfile: dev/app/Dockerfile
     environment:
       SERVICEWEAVER_CONFIG: weaver.toml
-      UID: ${UID}
-      XDG_DATA_HOME: /mnt
-      PROM_PUSHGATEWAY_ENDPOINT: localhost:9091
+      PROM_PUSHGATEWAY_ENDPOINT: pushgateway:9091
     working_dir: /app
-    network_mode: host
-    #ports:
-    #  - "8080:8080"
+    ports:
+      - "8088:8080"
     volumes:
       - ../:/app
-      - ${HOME}/.local/share/serviceweaver/:/mnt/serviceweaver
   db:
     image: mysql/mysql-server:8.0
     environment:

--- a/weaver.toml
+++ b/weaver.toml
@@ -4,21 +4,21 @@ binary = "./dkw"
 args = ["serve"]
 
 [single]
-listeners.graphql = {address = "localhost:8080"}
+listeners.graphql = {address = "0.0.0.0:8080"}
 
 [multi]
-listeners.graphql = {address = "localhost:8080"}
+listeners.graphql = {address = "0.0.0.0:8080"}
 
 ["dreamkast-weaver/internal/cfp/Service"]
 db_user = "user"
 db_password = "password"
-db_endpoint = "127.0.0.1"
-db_port = "13306"
+db_endpoint = "db"
+db_port = "3306"
 db_name = "cfp"
 
 ["dreamkast-weaver/internal/dkui/Service"]
 db_user = "user"
 db_password = "password"
-db_endpoint = "127.0.0.1"
-db_port = "13306"
+db_endpoint = "db"
+db_port = "3306"
 db_name = "dkui"


### PR DESCRIPTION
weaver single statusを使えるように host networkに変えていただいていましたが （ https://github.com/cloudnativedaysjp/dreamkast-weaver/pull/12/files ）、Docker Desktop for Macだとアクセスできないので、戻させてください。（使わないのですっかり忘れていました）
linuxの開発環境を用意しろという話でもあるのですが、dk向けの開発環境を別途揃えるのも大変なので、ご容赦いただきたいです（portabilityがないのもいまいちですし）