### PR TITLE
Build dkw for the target platform (fix ARM64 image)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,14 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
 # Build
-ARG GOOS=linux
-ARG GOARCH=amd64
+# TARGETOS/TARGETARCH are provided automatically by buildx from the target
+# platform (e.g. linux/arm64), so the binary matches the image architecture.
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
 COPY . .
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go build -ldflags="-s -w" -trimpath -tags timetzdata -o dkw cmd/dkw/main.go
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-s -w" -trimpath -tags timetzdata -o dkw cmd/dkw/main.go
 
 ### runner ###
 FROM gcr.io/distroless/static-debian11:nonroot


### PR DESCRIPTION
## 概要

Dockerfile が `GOARCH=amd64` をハードコードしていたため、buildx が ARM64 ネイティブランナーで `linux/arm64` イメージをビルドしても **中身の `/dkw` は amd64 バイナリ**になっていました。

ECS Fargate を ARM64 (Graviton) に切り替えたところ、`dkw-dbmigrate` / `dkw-serve` が以下で起動失敗します:

```
exec /dkw: exec format error
```

## 変更内容

buildx が target platform から自動で渡す `TARGETOS` / `TARGETARCH` を使い、ビルドされるバイナリがイメージのアーキと一致するようにします。マルチアーチ manifest の各プラットフォームで正しいバイナリになります。デフォルト値を残しているので素の `docker build` の挙動は不変です。

```diff
-ARG GOOS=linux
-ARG GOARCH=amd64
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
...
-    CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go build ...
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build ...
```

## マージ後

新しい `main-<sha>` イメージが正しい arm64 バイナリ込みのマルチアーチで publish されます。dreamkast-infra 側の stg `dreamkast_weaver` タグを新 sha に更新すれば weaver が ARM で起動できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)