### PR TITLE
Drop defaults on TARGETOS/TARGETARCH so buildx sets the arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,12 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
 # Build
-# TARGETOS/TARGETARCH are provided automatically by buildx from the target
-# platform (e.g. linux/arm64), so the binary matches the image architecture.
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+# TARGETOS/TARGETARCH are predefined ARGs that buildx populates from the target
+# platform (e.g. linux/arm64). They MUST be redeclared without a default value,
+# otherwise the default shadows the value buildx injects and the binary is built
+# for the wrong architecture.
+ARG TARGETOS
+ARG TARGETARCH
 COPY . .
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \


### PR DESCRIPTION
## 概要

前回の修正 #135 では `ARG TARGETARCH=amd64` と**デフォルト値付き**で宣言していました。`TARGETOS`/`TARGETARCH` は buildx が `--platform` から自動注入する predefined ARG で、**デフォルト値を付けるとそれが buildx の値を上書き（shadow）**してしまいます。

その結果、arm64 ビルドでも依然として amd64 でコンパイルされていました（run 28368964120 の arm64 ジョブログ）:

```
#17 [builder 5/5] RUN ... CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ... -o dkw
```

→ arm64 イメージ内のバイナリが amd64 のままで、ARM タスクが `exec /dkw: exec format error` で起動失敗し続けます。

## 変更内容

Docker の仕様どおり、`TARGETOS`/`TARGETARCH` を**デフォルト値なし**で再宣言します。これで `linux/arm64` ビルドでは `GOARCH=arm64`、`linux/amd64` では `GOARCH=amd64` と、ターゲットに一致したバイナリが生成されます。素の `docker build`（--platform 無し）でもホストのアーキが自動で入ります。

```diff
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
```

## マージ後

新しい `main-<sha>` イメージで arm64 バイナリが正しく入ります。gitops により infra stg の `dreamkast_weaver` タグが自動バンプされ、stg が再デプロイされて weaver が ARM で起動できるようになります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)